### PR TITLE
Adding Notes to the API docs

### DIFF
--- a/data/actions.json
+++ b/data/actions.json
@@ -1164,28 +1164,14 @@
     "value": "ADDED_A_NOTE",
     "msg": "Added a Note",
     "help_text": "When an Administrator adds a Note.",
-    "subject_types": [
-      "Tutor",
-      "Affiliate",
-      "Client",
-      "Student",
-      "Job",
-      "Lesson"
-    ]
+    "subject_types": ["Note"]
   },
   {
     "key": "EDITED_A_NOTE",
     "value": "EDITED_A_NOTE",
     "msg": "Edited a Note",
     "help_text": "When an Administrator edits a Note.",
-    "subject_types": [
-      "Tutor",
-      "Affiliate",
-      "Client",
-      "Student",
-      "Job",
-      "Lesson"
-    ]
+    "subject_types": ["Note"]
   },
   {
     "key": "DELETED_A_NOTE",
@@ -1227,7 +1213,7 @@
     "value": "CREATED_A_TASK",
     "msg": "Created a Task",
     "help_text": "When an Administrator creates a Task.",
-    "subject_types": []
+    "subject_types": ["Task"]
   },
   {
     "key": "CHANGED_CLIENTS_AGENT",
@@ -1261,7 +1247,7 @@
     "value": "EDITED_A_TASK",
     "msg": "Edited a Task",
     "help_text": "When an Administrator edits a Task.",
-    "subject_types": []
+    "subject_types": ["Task"]
   },
   {
     "key": "ADDED_A_LABEL_TO_A_SERVICE",

--- a/data/actions.json
+++ b/data/actions.json
@@ -1164,14 +1164,28 @@
     "value": "ADDED_A_NOTE",
     "msg": "Added a Note",
     "help_text": "When an Administrator adds a Note.",
-    "subject_types": ["Note"]
+    "subject_types": [
+      "Tutor",
+      "Affiliate",
+      "Client",
+      "Student",
+      "Job",
+      "Lesson"
+    ]
   },
   {
     "key": "EDITED_A_NOTE",
     "value": "EDITED_A_NOTE",
     "msg": "Edited a Note",
     "help_text": "When an Administrator edits a Note.",
-    "subject_types": ["Note"]
+    "subject_types": [
+      "Tutor",
+      "Affiliate",
+      "Client",
+      "Student",
+      "Job",
+      "Lesson"
+    ]
   },
   {
     "key": "DELETED_A_NOTE",
@@ -1213,7 +1227,7 @@
     "value": "CREATED_A_TASK",
     "msg": "Created a Task",
     "help_text": "When an Administrator creates a Task.",
-    "subject_types": ["Task"]
+    "subject_types": []
   },
   {
     "key": "CHANGED_CLIENTS_AGENT",
@@ -1247,7 +1261,7 @@
     "value": "EDITED_A_TASK",
     "msg": "Edited a Task",
     "help_text": "When an Administrator edits a Task.",
-    "subject_types": ["Task"]
+    "subject_types": []
   },
   {
     "key": "ADDED_A_LABEL_TO_A_SERVICE",

--- a/extensions.py
+++ b/extensions.py
@@ -55,6 +55,8 @@ SUBJECT_TYPE_HREF = {
     'Ad Hoc Charge Category': 'ahc-categories',
     'Application': 'tenders',
     'Report': 'reports',
+    'Task': 'tasks',
+    'Note': 'notes',
 }
 
 

--- a/pages/api.yml
+++ b/pages/api.yml
@@ -71,6 +71,10 @@ endpoint_sections:
     id: labels
     layout: /labels/labels.yml
   -
+    title: Notes
+    id: note
+    layout: /notes/notes.yml
+  -
     title: Payment Orders
     id: payment-orders
     layout: /payment-orders/pos.yml

--- a/pages/notes/get-a-note.json
+++ b/pages/notes/get-a-note.json
@@ -1,0 +1,19 @@
+{
+    "id": 1,
+    "dt_created": "2023-08-16T15:40:18.922862Z",
+    "dt_updated": "2023-08-16T15:40:18.922874Z",
+    "creator": {
+        "id": 2,
+        "first_name": "Diana",
+        "last_name": "Lafayette",
+        "email": "diana_lafayette@testagency.example.com"
+    },
+    "text": "This is a test note.",
+    "focus": {
+        "id": 62,
+        "first_name": "Jamie",
+        "last_name": "Hoskins",
+        "email": "jamie_hoskins@testagency.example.com",
+        "url": "http://localhost:8000/api/clients/62/"
+    }
+}

--- a/pages/notes/get-a-note.md
+++ b/pages/notes/get-a-note.md
@@ -1,0 +1,3 @@
+### Get a Note
+
+Returns the details of an existing Note. You only need to specify the unique `id` of the Note to get the correct details.

--- a/pages/notes/get-a-note.py
+++ b/pages/notes/get-a-note.py
@@ -1,0 +1,5 @@
+import pprint, requests
+
+headers = {'Authorization': 'token <API KEY>'}
+r = requests.get('https://secure.tutorcruncher.com/api/notes/<id>/', headers=headers)
+pprint.pprint(r.json())

--- a/pages/notes/list-all-notes.json
+++ b/pages/notes/list-all-notes.json
@@ -1,0 +1,31 @@
+{
+    "count": 3,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "id": 3,
+            "dt_created": "2023-08-16T16:05:54.465325Z",
+            "dt_updated": "2023-08-16T16:05:54.465348Z",
+            "creator": 2,
+            "text": "This note is on an appointment.",
+            "url": "http://localhost:8000/api/notes/3/"
+        },
+        {
+            "id": 2,
+            "dt_created": "2023-08-16T16:05:37.596813Z",
+            "dt_updated": "2023-08-16T16:05:37.596842Z",
+            "creator": 2,
+            "text": "This is a note on a job.",
+            "url": "http://localhost:8000/api/notes/2/"
+        },
+        {
+            "id": 1,
+            "dt_created": "2023-08-16T15:40:18.922862Z",
+            "dt_updated": "2023-08-16T15:40:18.922874Z",
+            "creator": 2,
+            "text": "* test",
+            "url": "http://localhost:8000/api/notes/1/"
+        }
+    ]
+}

--- a/pages/notes/list-all-notes.md
+++ b/pages/notes/list-all-notes.md
@@ -1,0 +1,3 @@
+### List all Notes
+
+Returns a list of all your Notes. The notes are sorted by id, with the largest `id` first.

--- a/pages/notes/list-all-notes.py
+++ b/pages/notes/list-all-notes.py
@@ -1,0 +1,5 @@
+import pprint, requests
+
+headers = {'Authorization': 'token <API KEY>'}
+r = requests.get('https://secure.tutorcruncher.com/api/notes/', headers=headers)
+pprint.pprint(r.json())

--- a/pages/notes/note-object.md
+++ b/pages/notes/note-object.md
@@ -1,0 +1,3 @@
+### Note Object
+
+Notes can be attached to Clients, Tutors, Agents (Affiliates), Students, Services and Appointments.

--- a/pages/notes/note-object.yml
+++ b/pages/notes/note-object.yml
@@ -1,0 +1,42 @@
+attributes:
+  -
+    name: id
+    type: integer
+    description: Unique identifier for the object.
+  -
+    name: dt_created
+    type: string
+    description: The date the Note was created.
+  -
+    name: dt_updated
+    type: string
+    description: The date the Note was last updated.
+  -
+    name: creator
+    type: object
+    description: The creator of the Note.
+    children:
+      -
+        name: id
+        type: integer
+        description: The ID of the note creator.
+      -
+        name: first_name
+        type: string
+        description: The first name of the note creator.
+      -
+        name: last_name
+        type: string
+        description: The last name of the note creator.
+      -
+        name: email
+        type: string
+        description: The email address of the note creator.
+  -
+    name: text
+    type: string
+    description: The text of the Note.
+  -
+    name: focus
+    type: object
+    description: Details about the object the Note was added to.

--- a/pages/notes/notes.yml
+++ b/pages/notes/notes.yml
@@ -1,0 +1,24 @@
+sections:
+  -
+    title: Note Object
+    id: note-object
+    description: /notes/note-object.md
+    attributes: /notes/note-object.yml
+    response: /notes/get-a-note.json
+    response_title: OBJECT
+  -
+    title: List all notes
+    id: list-all-notes
+    description: /notes/list-all-notes.md
+    code: /notes/list-all-notes.py
+    code_type: GET
+    code_url: /api/notes/
+    response: /notes/list-all-notes.json
+  -
+    title: Get a note
+    id: get-a-note
+    description: /notes/get-a-note.md
+    code: /notes/get-a-note.py
+    code_type: GET
+    code_url: /api/notes/<id>/
+    response: /notes/get-a-note.json


### PR DESCRIPTION
Adding the Notes object to the API docs, to be merged when https://github.com/tutorcruncher/TutorCruncher2/pull/12444 gets deployed

TODO - After notes gets added to the api, we need to run get_actions.py to update the action subject types.