### PR TITLE
Added received_notifications to Client

### DIFF
--- a/data/actions.json
+++ b/data/actions.json
@@ -1783,5 +1783,59 @@
     "msg": "Deleted a Lesson Recording details",
     "help_text": "When a lesson recording has been deleted.",
     "subject_types": []
+  },
+  {
+    "key": "CREATED_A_PACKAGE",
+    "value": "CREATED_A_PACKAGE",
+    "msg": "Created a Package",
+    "help_text": "When a package has been created.",
+    "subject_types": [
+      "Package"
+    ]
+  },
+  {
+    "key": "EDITED_A_PACKAGE",
+    "value": "EDITED_A_PACKAGE",
+    "msg": "Edited a Package",
+    "help_text": "When a package has been edited.",
+    "subject_types": [
+      "Package"
+    ]
+  },
+  {
+    "key": "DELETED_A_PACKAGE",
+    "value": "DELETED_A_PACKAGE",
+    "msg": "Deleted a Package",
+    "help_text": "When a package has been deleted.",
+    "subject_types": [
+      "Package"
+    ]
+  },
+  {
+    "key": "CLIENT_PURCHASED_PACKAGE",
+    "value": "CLIENT_PURCHASED_PACKAGE",
+    "msg": "Client purchased a Package",
+    "help_text": "When a client has purchased a package.",
+    "subject_types": [
+      "Package"
+    ]
+  },
+  {
+    "key": "ADDED_GC_CUSTOMER_DATA",
+    "value": "ADDED_GC_CUSTOMER_DATA",
+    "msg": "Added new GoCardless details",
+    "help_text": "When a client adds new GoCardless details",
+    "subject_types": [
+      "Client"
+    ]
+  },
+  {
+    "key": "REMOVED_GC_CUSTOMER_DATA",
+    "value": "REMOVED_GC_CUSTOMER_DATA",
+    "msg": "Removed GoCardless details",
+    "help_text": "When a client or admin removes GoCardless details",
+    "subject_types": [
+      "Client"
+    ]
   }
 ]

--- a/extensions.py
+++ b/extensions.py
@@ -57,6 +57,7 @@ SUBJECT_TYPE_HREF = {
     'Report': 'reports',
     'Task': 'tasks',
     'Note': 'notes',
+    'Package': 'package',
 }
 
 

--- a/pages/clients/client-object.json
+++ b/pages/clients/client-object.json
@@ -19,7 +19,15 @@
   },
   "status": "live",
   "is_taxable": true,
-  "notify_via_email": true,
+    "received_notifications": [
+    "invoice_reminders",
+    "invoices",
+    "apt_reminders",
+    "pfi_reminders",
+    "credit-requests",
+    "low_balance_reminders",
+    "broadcasts"
+    ],
   "charge_via_branch": false,
   "invoices_count": 4,
   "payment_pending": "100.50",

--- a/pages/clients/client-object.json
+++ b/pages/clients/client-object.json
@@ -19,7 +19,7 @@
   },
   "status": "live",
   "is_taxable": true,
-    "received_notifications": [
+  "received_notifications": [
     "invoice_reminders",
     "invoices",
     "apt_reminders",
@@ -27,7 +27,7 @@
     "credit-requests",
     "low_balance_reminders",
     "broadcasts"
-    ],
+  ],
   "charge_via_branch": false,
   "invoices_count": 4,
   "payment_pending": "100.50",

--- a/pages/clients/client-object.yml
+++ b/pages/clients/client-object.yml
@@ -75,9 +75,9 @@ attributes:
     type: boolean
     description: Whether or not tax should be paid on payments from this Client.
   -
-    name: notify_via_email
-    type: boolean
-    description: If `false` the Client will receive no emails.
+    name: received_notifications
+    type: array
+    description: An array of the Client's received notifications. choices are `broadcasts`, `apt_reminders`, `low_balance_reminders`, `invoice_reminders`, `pfi_reminders`, `invoices`, `credit_requests`
   -
     name: charge_via_branch
     type: boolean

--- a/pages/clients/create-a-client.json
+++ b/pages/clients/create-a-client.json
@@ -21,7 +21,15 @@
     },
     "status": "live",
     "is_taxable": true,
-    "notify_via_email": true,
+    "received_notifications": [
+    "invoice_reminders",
+    "invoices",
+    "apt_reminders",
+    "pfi_reminders",
+    "credit-requests",
+    "low_balance_reminders",
+    "broadcasts"
+    ],
     "charge_via_branch": false,
     "invoices_count": 4,
     "payment_pending": "100.50",

--- a/pages/clients/create-a-client.json
+++ b/pages/clients/create-a-client.json
@@ -22,13 +22,13 @@
     "status": "live",
     "is_taxable": true,
     "received_notifications": [
-    "invoice_reminders",
-    "invoices",
-    "apt_reminders",
-    "pfi_reminders",
-    "credit-requests",
-    "low_balance_reminders",
-    "broadcasts"
+      "invoice_reminders",
+      "invoices",
+      "apt_reminders",
+      "pfi_reminders",
+      "credit-requests",
+      "low_balance_reminders",
+      "broadcasts"
     ],
     "charge_via_branch": false,
     "invoices_count": 4,

--- a/pages/clients/create-a-client.py
+++ b/pages/clients/create-a-client.py
@@ -19,7 +19,15 @@ data = {
     },
     'status': 'live',
     'is_taxable': False,
-    'notify_via_email': True,
+    "received_notifications": [
+    "invoice_reminders",
+    "invoices",
+    "apt_reminders",
+    "pfi_reminders",
+    "credit-requests",
+    "low_balance_reminders",
+    "broadcasts"
+    ],
     'change_via_branch': True,
     'auto_charge': 0,
     'associated_admin': 12,

--- a/pages/clients/create-a-client.py
+++ b/pages/clients/create-a-client.py
@@ -19,14 +19,14 @@ data = {
     },
     'status': 'live',
     'is_taxable': False,
-    "received_notifications": [
-    "invoice_reminders",
-    "invoices",
-    "apt_reminders",
-    "pfi_reminders",
-    "credit-requests",
-    "low_balance_reminders",
-    "broadcasts"
+    'received_notifications': [
+        'invoice_reminders',
+        'invoices',
+        'apt_reminders',
+        'pfi_reminders',
+        'credit-requests',
+        'low_balance_reminders',
+        'broadcasts'
     ],
     'change_via_branch': True,
     'auto_charge': 0,

--- a/pages/clients/get-a-client.json
+++ b/pages/clients/get-a-client.json
@@ -19,7 +19,7 @@
   },
   "status": "live",
   "is_taxable": true,
-    "received_notifications": [
+  "received_notifications": [
     "invoice_reminders",
     "invoices",
     "apt_reminders",

--- a/pages/clients/get-a-client.json
+++ b/pages/clients/get-a-client.json
@@ -19,7 +19,15 @@
   },
   "status": "live",
   "is_taxable": true,
-  "notify_via_email": true,
+    "received_notifications": [
+    "invoice_reminders",
+    "invoices",
+    "apt_reminders",
+    "pfi_reminders",
+    "credit-requests",
+    "low_balance_reminders",
+    "broadcasts"
+    ],
   "charge_via_branch": false,
   "invoices_count": 4,
   "payment_pending": "100.50",

--- a/pages/clients/update-a-client.json
+++ b/pages/clients/update-a-client.json
@@ -21,7 +21,15 @@
     },
     "status": "live",
     "is_taxable": true,
-    "notify_via_email": true,
+    "received_notifications": [
+    "invoice_reminders",
+    "invoices",
+    "apt_reminders",
+    "pfi_reminders",
+    "credit-requests",
+    "low_balance_reminders",
+    "broadcasts"
+    ],
     "charge_via_branch": false,
     "invoices_count": 4,
     "payment_pending": "100.50",

--- a/pages/clients/update-a-client.json
+++ b/pages/clients/update-a-client.json
@@ -22,13 +22,13 @@
     "status": "live",
     "is_taxable": true,
     "received_notifications": [
-    "invoice_reminders",
-    "invoices",
-    "apt_reminders",
-    "pfi_reminders",
-    "credit-requests",
-    "low_balance_reminders",
-    "broadcasts"
+      "invoice_reminders",
+      "invoices",
+      "apt_reminders",
+      "pfi_reminders",
+      "credit-requests",
+      "low_balance_reminders",
+      "broadcasts"
     ],
     "charge_via_branch": false,
     "invoices_count": 4,


### PR DESCRIPTION
Close #169 
- removed `notify_via_email`﻿ as it no longer exists and changed with `received_notifications`
