### PR TITLE
Clarify PUT /appointments/<id>/ ignores rcras/cjas

### DIFF
--- a/pages/appointments/update-an-appointment.md
+++ b/pages/appointments/update-an-appointment.md
@@ -1,6 +1,7 @@
 ### Updating an Appointment
 
 Updating an Appointment is similar to [Creating an Appointment](#create-an-appointment). One major difference is
-that you cannot add, edit or delete Recipients or Contractors on the Appointment. To do this you must use the endpoints
-[Add/Edit Recipient on Appointment](#create-update-rcra), [Remove Recipient from Appointment](#remove-rcra),
-[Add/Edit Contractor on Appointment](#create-update-cja) or [Remove Contractor from Appointment](#remove-cja). Note that only Appointments with status `Planned` can be updated.
+that you cannot add, edit or delete Recipients or Contractors on the Appointment — any `rcras` or `cjas`
+in the request body are **ignored**. To manage them, use [Add/Edit Recipient on Appointment](#create-update-rcra),
+[Remove Recipient from Appointment](#remove-rcra), [Add/Edit Contractor on Appointment](#create-update-cja)
+or [Remove Contractor from Appointment](#remove-cja). Note that only Appointments with status `Planned` can be updated.


### PR DESCRIPTION
## Technical description for developers

The `update-an-appointment` description already said you can't manage Recipients/Contractors via PUT, but it didn't say what happens if you send `rcras` or `cjas` in the body. Mirrors [tutorcruncher/TutorCruncher2#16356](https://github.com/tutorcruncher/TutorCruncher2/pull/16356), where the API was changed so:

- `AppointmentUpdateSerializer` no longer declares the writable nested `cjas`/`rcras` fields (they're declared on the create serializer only).
- Sending them on PUT is now silently ignored instead of raising the previous `AssertionError` (which surfaced in Sentry as a 500).

This doc tweak just makes that contract explicit — "any `rcras` or `cjas` in the request body are **ignored**".

## Description for non-devs

Updates the documentation for the "Update an Appointment" endpoint to make it clearer that any tutor/student data sent in the request body is ignored — you must use the dedicated tutor/student endpoints to change those.