### PR TITLE
Document pdf_url field on invoice, PO and proforma invoice objects

### DIFF
--- a/pages/invoices/create-an-invoice.json
+++ b/pages/invoices/create-an-invoice.json
@@ -89,6 +89,7 @@
       "display_id": "INV-892",
       "gross": "125.00",
       "net": "104.17",
+      "pdf_url": "https://tutorcruncher-documents.s3.amazonaws.com/abc123/docs/invoices/c4e8f1a2.pdf?AWSAccessKeyId=AKIAEXAMPLE&Signature=Qz7vEXAMPLEsig%3D&Expires=1735689600",
       "status": "unpaid",
       "still_to_pay": 125.0,
       "tax": "20.83"

--- a/pages/invoices/get-an-invoice.json
+++ b/pages/invoices/get-an-invoice.json
@@ -116,6 +116,7 @@
   "display_id": "INV-48",
   "gross": "340.90",
   "net": 284.08,
+  "pdf_url": "https://tutorcruncher-documents.s3.amazonaws.com/abc123/docs/invoices/3f9a8b2c.pdf?AWSAccessKeyId=AKIAEXAMPLE&Signature=Hk3mEXAMPLEsig%3D&Expires=1735689600",
   "status": "paid",
   "still_to_pay": 0.0,
   "tax": "56.82"

--- a/pages/invoices/invoice-object.json
+++ b/pages/invoices/invoice-object.json
@@ -116,6 +116,7 @@
   "display_id": "INV-48",
   "gross": "340.90",
   "net": 284.08,
+  "pdf_url": "https://tutorcruncher-documents.s3.amazonaws.com/abc123/docs/invoices/3f9a8b2c.pdf?AWSAccessKeyId=AKIAEXAMPLE&Signature=Hk3mEXAMPLEsig%3D&Expires=1735689600",
   "status": "paid",
   "still_to_pay": 0.0,
   "tax": "56.82"

--- a/pages/invoices/invoice-object.yml
+++ b/pages/invoices/invoice-object.yml
@@ -105,6 +105,13 @@ attributes:
     type: decimal
     description: Invoice's net amount.
   -
+    name: pdf_url
+    type: string
+    description: |
+      A temporary, signed link to download the PDF of the Invoice. The PDF is generated on the first request,
+      so that call may take slightly longer. The link expires after a short period, so request the Invoice
+      again to obtain a fresh one.
+  -
     name: status
     type: string
     description: |

--- a/pages/payment-orders/get-a-po.json
+++ b/pages/payment-orders/get-a-po.json
@@ -187,6 +187,7 @@
     "date_void": null,
     "date_paid": null,
     "display_id": "PO-46",
+    "pdf_url": "https://tutorcruncher-documents.s3.amazonaws.com/abc123/docs/client-reports/7d1e4a9f.pdf?AWSAccessKeyId=AKIAEXAMPLE&Signature=Pm2nEXAMPLEsig%3D&Expires=1735689600",
     "status": "unpaid",
     "payee": {
         "id": 1865751,

--- a/pages/payment-orders/po-object.json
+++ b/pages/payment-orders/po-object.json
@@ -43,6 +43,7 @@
     "date_void": null,
     "date_paid": null,
     "display_id": "PO-46",
+    "pdf_url": "https://tutorcruncher-documents.s3.amazonaws.com/abc123/docs/client-reports/7d1e4a9f.pdf?AWSAccessKeyId=AKIAEXAMPLE&Signature=Pm2nEXAMPLEsig%3D&Expires=1735689600",
     "status": "unpaid",
     "payee": {
         "id": 1865751,

--- a/pages/payment-orders/po-object.yml
+++ b/pages/payment-orders/po-object.yml
@@ -98,6 +98,13 @@ attributes:
     type: string
     description: Payment Order's unique display name.
   -
+    name: pdf_url
+    type: string
+    description: |
+      A temporary, signed link to download the PDF of the Payment Order. The PDF is generated on the first request,
+      so that call may take slightly longer. The link expires after a short period, so request the Payment Order
+      again to obtain a fresh one.
+  -
     name: amount
     type: decimal
     description: Payment Order's amount.

--- a/pages/proforma-invoices/create-a-pfi.json
+++ b/pages/proforma-invoices/create-a-pfi.json
@@ -21,6 +21,7 @@
       "rcra": null
     }
   ],
+  "pdf_url": "https://tutorcruncher-documents.s3.amazonaws.com/abc123/docs/proforma-invoice/e2d9f4b7.pdf?AWSAccessKeyId=AKIAEXAMPLE&Signature=Ld5cEXAMPLEsig%3D&Expires=1735689600",
   "service_recipients": [],
   "status": "unpaid",
   "still_to_pay": 120.0

--- a/pages/proforma-invoices/get-a-proforma-invoice.json
+++ b/pages/proforma-invoices/get-a-proforma-invoice.json
@@ -20,6 +20,7 @@
       "rcra": null
     }
   ],
+  "pdf_url": "https://tutorcruncher-documents.s3.amazonaws.com/abc123/docs/proforma-invoice/b6a0c3d5.pdf?AWSAccessKeyId=AKIAEXAMPLE&Signature=Tn4xEXAMPLEsig%3D&Expires=1735689600",
   "service_recipients": [],
   "status": "unpaid",
   "still_to_pay": 60.0

--- a/pages/proforma-invoices/proforma-invoice-object.json
+++ b/pages/proforma-invoices/proforma-invoice-object.json
@@ -20,6 +20,7 @@
       "rcra": null
     }
   ],
+  "pdf_url": "https://tutorcruncher-documents.s3.amazonaws.com/abc123/docs/proforma-invoice/b6a0c3d5.pdf?AWSAccessKeyId=AKIAEXAMPLE&Signature=Tn4xEXAMPLEsig%3D&Expires=1735689600",
   "service_recipients": [],
   "status": "unpaid",
   "still_to_pay": 60.0

--- a/pages/proforma-invoices/proforma-invoice-object.yml
+++ b/pages/proforma-invoices/proforma-invoice-object.yml
@@ -68,6 +68,13 @@ attributes:
           Object for a linked Recipient on an Appointment. Object containes attributes `recipient`, `recipient_name`,
           `paying_client`, `paying_client_name`, and `charge_rate`.
   -
+    name: pdf_url
+    type: string
+    description: |
+      A temporary, signed link to download the PDF of the Proforma Invoice. The PDF is generated on the first
+      request, so that call may take slightly longer. The link expires after a short period, so request the
+      Proforma Invoice again to obtain a fresh one.
+  -
     name: service_recipients
     type: array
     description: An array of Recipient objects on the Proforma Invoice.


### PR DESCRIPTION
Documents the new read-only `pdf_url` attribute returned by the Invoice, Payment Order and Proforma Invoice API objects.

`pdf_url` is a temporary, signed link to download the item's PDF. The PDF is generated on the first request that needs it, and the link expires after a short period (request the object again for a fresh link).

### What changed
- Added the `pdf_url` attribute to the object schemas (`*-object.yml`) for invoices, payment orders and proforma invoices.
- Added `pdf_url` to the matching example responses (`*-object.json`, `get-*.json`, and the create responses for invoices/PFIs).
- List endpoints use the summary serializer and do not include `pdf_url`, so they're unchanged.

Pairs with TutorCruncher2 PR #16499.